### PR TITLE
Update the links to Unicode Utilities

### DIFF
--- a/functions.js
+++ b/functions.js
@@ -2389,7 +2389,7 @@ function printProperties ( codepoint ) {
         if (charType === IN_U_DB) out += `<tr><td>Unicode version:</td><td>${ age2VersionMap[cRecord[AGE_FIELD]] }</td></tr><tr>`
 
         // add link to CLDR properties demo
-        out += `<tr><td class="padBlockStart padBlockEnd" colspan="2"><a href="http://unicode.org/cldr/utility/character.jsp?a=${ cpHex }" target="cldr" style="font-size:110%;">Show more character properties</a></td></tr><tr>`
+        out += `<tr><td class="padBlockStart padBlockEnd" colspan="2"><a href="https://util.unicode.org/UnicodeJsps/character.jsp?a=${ cpHex }" target="cldr" style="font-size:110%;">Show more character properties</a></td></tr><tr>`
 
 
         if (charType !== PRIVATEUSE) {

--- a/makeSVGfunctions.js
+++ b/makeSVGfunctions.js
@@ -2283,7 +2283,7 @@ function printProperties ( codepoint ) {
         out += `<tr><td>Unicode version:</td><td>${ age2VersionMap[cRecord[AGE_FIELD]] }</td></tr><tr>`
 
         // add link to CLDR properties demo
-        out += `<tr><td class="padBlockStart padBlockEnd" colspan="2"><a href="http://unicode.org/cldr/utility/character.jsp?a=${ cpHex }" target="cldr" style="font-size:110%;">Show character properties</a></td></tr><tr>`
+        out += `<tr><td class="padBlockStart padBlockEnd" colspan="2"><a href="https://util.unicode.org/UnicodeJsps/character.jsp?a=${ cpHex }" target="cldr" style="font-size:110%;">Show character properties</a></td></tr><tr>`
 
 
 
@@ -2698,7 +2698,7 @@ function printPropertiesZ ( codepoint ) {
 			td.setAttribute('colspan', '2')
 			a = td.appendChild( document.createElement( 'a' ))
 			a.appendChild( document.createTextNode( 'Show character properties' ))
-			a.setAttribute( 'href', 'http://unicode.org/cldr/utility/character.jsp?a='+cpHex )
+			a.setAttribute( 'href', 'https://util.unicode.org/UnicodeJsps/character.jsp?a='+cpHex )
 			a.setAttribute( 'target', 'cldr' )
 			a.style.fontSize = '110%'
 			td.setAttribute('style', 'padding-bottom:15px;')
@@ -2789,7 +2789,7 @@ function printPropertiesZ ( codepoint ) {
 		//p.appendChild( document.createTextNode( 'More properties at ' ))
 		//a = p.appendChild( document.createElement( 'a' ))
 		//a.appendChild( document.createTextNode( 'See more Character Properties' ))
-		//a.setAttribute( 'href', 'http://unicode.org/cldr/utility/character.jsp?a='+cpHex )
+		//a.setAttribute( 'href', 'https://util.unicode.org/UnicodeJsps/character.jsp?a='+cpHex )
 		//a.setAttribute( 'target', 'cldr' )
 		//a.style.fontSize = '120%'
 		


### PR DESCRIPTION
This PR fixes the _Show more character properties_ link shown in the image below.


<img width="400" alt="图片" src="https://github.com/user-attachments/assets/f0457ed7-e59a-4bf4-80d5-e8a88544578e" />


I changed all occurrences of http://unicode.org/cldr/utility/character.js to https://util.unicode.org/UnicodeJsps/character.jsp.
The former URL has been broken for months, because it now redirects to itself. The https versions of it is also a self-redirection.

I don't know how to test UniView locally, but I guess this should work.


Relates-to: https://github.com/unicode-org/unicodetools/issues/127